### PR TITLE
Add flashing of bootloader and partition table

### DIFF
--- a/src/main/java/esp32/embedded/clion/openocd/FileChooseInput.java
+++ b/src/main/java/esp32/embedded/clion/openocd/FileChooseInput.java
@@ -244,8 +244,8 @@ public abstract class FileChooseInput extends TextFieldWithBrowseButton {
         }
 
         public String getPath() {
-            return Objects.requireNonNull(projectHome.findFileByRelativePath(getText())).getPath();
-//            return projectHome.getPath() + "/" + getText();
+//            return Objects.requireNonNull(projectHome.findFileByRelativePath(getText())).getPath();
+            return projectHome.getPath() + "/" + getText();
         }
 
         @Override

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
@@ -23,9 +23,11 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.concurrency.FutureResult;
+
 import java.io.File;
 import java.util.Objects;
 import java.util.concurrent.Future;
+
 import org.jdesktop.swingx.util.OS;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -93,9 +95,12 @@ public class OpenOcdComponent {
 
         commandLine.addParameters("-f", config.getBoardConfigFile());
 
+        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getBootBinPath() + " " + config.getBootOffset());
+        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getPartitionBinPath() + " " + config.getPartitionOffset());
+
         if (fileToLoad != null) { // Program Command
             String command =
-                    "program_esp32 " + fileToLoad.getAbsolutePath().replace(File.separatorChar, '/').replace(".elf",
+                    config.getProgramType().toString() + " " + fileToLoad.getAbsolutePath().replace(File.separatorChar, '/').replace(".elf",
                             ".bin");
             if (config.getOffset() != null && !config.getOffset().isEmpty())
                 command = command + " " + config.getOffset();

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
@@ -95,8 +95,8 @@ public class OpenOcdComponent {
 
         commandLine.addParameters("-f", config.getBoardConfigFile());
 
-        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getBootBinPath() + " " + config.getBootOffset());
-        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getPartitionBinPath() + " " + config.getPartitionOffset());
+        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getBootBinPath() + " " + config.getBootOffset() + " verify");
+        commandLine.addParameters("-c", config.getProgramType().toString() + " " + config.getPartitionBinPath() + " " + config.getPartitionOffset() + " verify");
 
         if (fileToLoad != null) { // Program Command
             String command =
@@ -104,6 +104,8 @@ public class OpenOcdComponent {
                             ".bin");
             if (config.getOffset() != null && !config.getOffset().isEmpty())
                 command = command + " " + config.getOffset();
+
+            command += " verify";
 
             commandLine.addParameters("-c", command);
         }

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
@@ -91,7 +91,7 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     }
 
     public enum ProgramType {
-        PROGRAM,
+        PROGRAM_ESP,
         PROGRAM_ESP32;
 
         @Override

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
@@ -4,16 +4,23 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.RuntimeConfigurationException;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfiguration;
 import com.jetbrains.cidr.execution.CidrCommandLineState;
 import com.jetbrains.cidr.execution.CidrExecutableDataHolder;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * (c) elmot on 29.9.2017.
@@ -23,19 +30,34 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     public static final int DEF_GDB_PORT = 3333;
     public static final int DEF_TELNET_PORT = 4444;
     public static final String DEF_PROGRAM_OFFSET = "0x10000";
+    public static final String DEF_BOOT_OFFSET = "0x0";
+    public static final String DEF_BOOT_BIN_PATH = "build/bootloader/bootloader.bin";
+
+    public static final String DEF_PART_OFFSET = "0x8000";
+    public static final String DEF_PART_BIN_PATH = "build/partition_table/partition-table.bin";
     public static final boolean DEF_HAR = true;
     public static final boolean DEF_FLUSH_REGS = true;
     public static final boolean DEF_BREAK_FUNCTION = true;
     public static final String DEF_BREAK_FUNCTION_NAME = "app_main";
+
+    public static final ProgramType DEF_PROGRAM_TYPE = ProgramType.PROGRAM_ESP32;
+
     private static final String ATTR_GDB_PORT = "gdb_port";
     private static final String ATTR_TELNET_PORT = "telnet_port";
     private static final String ATTR_BOARD_CONFIG = "board_config";
     private static final String ATTR_INTERFACE_CONFIG = "interface_config";
+    private static final String ATTR_BOOT_PATH_CONFIG = "boot_path_cfg";
+    private static final String ATTR_BOOT_OFFSET_CONFIG = "boot_offset_cfg";
+
+    private static final String ATTR_PART_PATH_CONFIG = "part_path_cfg";
+    private static final String ATTR_PART_OFFSET_CONFIG = "part_offset_cfg";
     public static final String ATTR_DOWNLOAD_TYPE = "download_type";
     public static final String ATTR_HAR = "halt_on_reset";
     public static final String ATTR_FLUSH_REGS = "flush_regs";
     public static final String ATTR_BREAK_FUNCTION = "break";
     public static final String ATTR_BREAK_FUNCTION_NAME = "break_function";
+
+    public static final String ATTR_PROGRAM_TYPE_CONFIG = "prog_type_cfg";
 
 
     private int gdbPort = DEF_GDB_PORT;
@@ -49,6 +71,13 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     private boolean initialBreak = DEF_BREAK_FUNCTION;
     private String initialBreakName = DEF_BREAK_FUNCTION_NAME;
 
+    private String bootloaderOffset = DEF_BOOT_OFFSET;
+    private String bootloaderBinPath = DEF_BOOT_BIN_PATH;
+    private String partitionOffset = DEF_PART_OFFSET;
+    private String partitionBinPath = DEF_PART_BIN_PATH;
+
+    private ProgramType programType = ProgramType.PROGRAM_ESP32;
+
     public enum DownloadType {
 
         ALWAYS,
@@ -58,6 +87,16 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         @Override
         public String toString() {
             return toBeautyString(super.toString());
+        }
+    }
+
+    public enum ProgramType {
+        PROGRAM,
+        PROGRAM_ESP32;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
         }
     }
 
@@ -111,6 +150,15 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         flushRegs = readBoolAttr(element, ATTR_FLUSH_REGS, DEF_FLUSH_REGS);
         initialBreak = readBoolAttr(element, ATTR_BREAK_FUNCTION, DEF_BREAK_FUNCTION);
         initialBreakName = element.getAttributeValue(ATTR_BREAK_FUNCTION_NAME, null, DEF_BREAK_FUNCTION_NAME);
+
+        bootloaderBinPath = element.getAttributeValue(ATTR_BOOT_PATH_CONFIG, null, DEF_BOOT_BIN_PATH);
+        bootloaderOffset = element.getAttributeValue(ATTR_BOOT_OFFSET_CONFIG, null, DEF_BOOT_OFFSET);
+
+        partitionBinPath = element.getAttributeValue(ATTR_PART_PATH_CONFIG, null, DEF_PART_BIN_PATH);
+        partitionOffset = element.getAttributeValue(ATTR_PART_OFFSET_CONFIG, null, DEF_PART_OFFSET);
+
+        String programTypeStr = element.getAttributeValue(ATTR_PROGRAM_TYPE_CONFIG);
+        programType = programTypeStr != null ? ProgramType.valueOf(programTypeStr) : DEF_PROGRAM_TYPE;
     }
 
     private int readIntAttr(@NotNull Element element, String name, int def) {
@@ -157,6 +205,17 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         element.setAttribute(ATTR_BREAK_FUNCTION, String.valueOf(initialBreak));
         element.setAttribute(ATTR_BREAK_FUNCTION_NAME, initialBreakName);
 
+        if (bootloaderBinPath != null) {
+            element.setAttribute(ATTR_BOOT_PATH_CONFIG, bootloaderBinPath);
+        }
+        element.setAttribute(ATTR_BOOT_OFFSET_CONFIG, Objects.requireNonNullElse(bootloaderOffset, DEF_BOOT_OFFSET));
+
+        if (partitionBinPath != null) {
+            element.setAttribute(ATTR_PART_PATH_CONFIG, partitionBinPath);
+        }
+        element.setAttribute(ATTR_PART_OFFSET_CONFIG, Objects.requireNonNullElse(partitionOffset, DEF_PART_OFFSET));
+
+        element.setAttribute(ATTR_PROGRAM_TYPE_CONFIG, programType.name());
     }
 
     @Override
@@ -256,5 +315,45 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
 
     public void setInitialBreakName(String initialBreakName) {
         this.initialBreakName = initialBreakName;
+    }
+
+    public String getBootOffset() {
+        return bootloaderOffset;
+    }
+
+    public void setBootOffset(String offset) {
+        this.bootloaderOffset = offset;
+    }
+
+    public String getPartitionOffset() {
+        return partitionOffset;
+    }
+
+    public void setPartitionOffset(String offset) {
+        this.partitionOffset = offset;
+    }
+
+    public String getBootBinPath() {
+        return bootloaderBinPath;
+    }
+
+    public void setBootBinPath(String path) {
+        this.bootloaderBinPath = path;
+    }
+
+    public String getPartitionBinPath() {
+        return partitionBinPath;
+    }
+
+    public void setPartitionBinPath(String path) {
+        this.partitionBinPath = path;
+    }
+
+    public ProgramType getProgramType() {
+        return programType;
+    }
+
+    public void setProgramType(ProgramType programType) {
+        this.programType = programType;
     }
 }

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
@@ -1,9 +1,13 @@
 package esp32.embedded.clion.openocd;
 
 import com.intellij.execution.ui.CommonProgramParametersPanel;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.fields.ExtendableTextField;
 import com.intellij.ui.components.fields.IntegerField;
 import com.intellij.util.ui.GridBag;
@@ -11,6 +15,7 @@ import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfiguration;
 import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfigurationSettingsEditor;
 import com.jetbrains.cidr.cpp.execution.CMakeBuildConfigurationHelper;
 import esp32.embedded.clion.openocd.OpenOcdConfiguration.DownloadType;
+import esp32.embedded.clion.openocd.OpenOcdConfiguration.ProgramType;
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
@@ -32,8 +37,15 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
     private ExtendableTextField initialBreakpointName;
     private FileChooseInput boardConfigFile;
     private FileChooseInput interfaceConfigFile;
+
+    private FileChooseInput.BinFile bootloaderFile;
+    private ExtendableTextField bootloaderOffset;
+    private FileChooseInput.BinFile partitionTableFile;
+    private ExtendableTextField partitionTableOffset;
     private String openocdHome;
     private JXRadioGroup<DownloadType> downloadGroup;
+
+    private JXRadioGroup<ProgramType> programType;
 
 
     @SuppressWarnings("WeakerAccess")
@@ -54,18 +66,26 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
         String interfaceConfig = interfaceConfigFile.getText().trim();
         ocdConfiguration.setInterfaceConfigFile(interfaceConfig.isEmpty() ? null : interfaceConfig);
 
+        String bootPath = bootloaderFile.getPath().trim();
+        ocdConfiguration.setBootBinPath(bootPath.isEmpty() ? null: bootPath);
+
+        String partPath = partitionTableFile.getPath().trim();
+        ocdConfiguration.setPartitionBinPath(partPath.isEmpty() ? null: partPath);
+
         gdbPort.validateContent();
         telnetPort.validateContent();
         ocdConfiguration.setGdbPort(gdbPort.getValue());
         ocdConfiguration.setTelnetPort(telnetPort.getValue());
         ocdConfiguration.setDownloadType(downloadGroup.getSelectedValue());
+        ocdConfiguration.setProgramType(programType.getSelectedValue());
 
         ocdConfiguration.setOffset(offset.getText());
+        ocdConfiguration.setBootOffset(bootloaderOffset.getText());
+        ocdConfiguration.setPartitionOffset(partitionTableOffset.getText());
         ocdConfiguration.setHAR(harCheck.isSelected());
         ocdConfiguration.setFlushRegs(flushRegsCheck.isSelected());
         ocdConfiguration.setInitialBreak(initialBreakpointCheck.isSelected());
         ocdConfiguration.setInitialBreakName(initialBreakpointName.getText());
-
     }
 
     @Override
@@ -79,12 +99,22 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
         boardConfigFile.setText(ocd.getBoardConfigFile());
         interfaceConfigFile.setText(ocd.getInterfaceConfigFile());
 
+        String root = ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0]).getContentRoots()[0].getPath();
+        String bootBinPath = ocd.getBootBinPath().replaceAll(root+"/", "");
+        bootloaderFile.setText(bootBinPath);
+
+        String partitionPath = ocd.getPartitionBinPath().replaceAll(root+"/", "");
+        partitionTableFile.setText(partitionPath);
+
         gdbPort.setText("" + ocd.getGdbPort());
 
         telnetPort.setText("" + ocd.getTelnetPort());
         downloadGroup.setSelectedValue(ocd.getDownloadType());
+        programType.setSelectedValue(ocd.getProgramType());
 
         offset.setText(ocd.getOffset());
+        bootloaderOffset.setText(ocd.getBootOffset());
+        partitionTableOffset.setText(ocd.getPartitionOffset());
         harCheck.setSelected(ocd.getHAR());
         flushRegsCheck.setSelected(ocd.getFlushRegs());
         initialBreakpointCheck.setSelected(ocd.getInitialBreak());
@@ -112,6 +142,33 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
                 this::getOpenocdHome);
         panel.add(interfaceConfigFile, gridBag.next().coverLine());
 
+        VirtualFile contentRoot = ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0]).getContentRoots()[0];
+
+        JPanel bootloaderPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
+        bootloaderPanel.add(new JLabel("Bootloader binary:"));
+        bootloaderFile = new FileChooseInput.BinFile("Bootloader file", VfsUtil.getUserHomeDir(), contentRoot);
+        bootloaderPanel.add(bootloaderFile);
+
+        bootloaderPanel.add(new JLabel("Bootloader offset:"));
+        bootloaderOffset = addOffsetInput(OpenOcdConfiguration.DEF_BOOT_OFFSET);
+        bootloaderPanel.add(bootloaderOffset);
+
+        panel.add(bootloaderPanel, gridBag.nextLine().next().coverLine());
+
+        JPanel partitionPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
+        partitionPanel.add(new JLabel("Partition Table binary:"));
+        partitionTableFile = new FileChooseInput.BinFile("Partition Table file", VfsUtil.getUserHomeDir(), contentRoot);
+        partitionPanel.add(partitionTableFile);
+
+        partitionPanel.add(new JLabel("Partition Table offset:"));
+        partitionTableOffset = addOffsetInput(OpenOcdConfiguration.DEF_PART_OFFSET);
+        partitionPanel.add(partitionTableOffset);
+
+        panel.add(partitionPanel, gridBag.nextLine().next().coverLine());
+
+        panel.add(new JLabel("OpenOCD command:"), gridBag.nextLine().next());
+        programType = new JXRadioGroup<>(ProgramType.values());
+        panel.add(programType,gridBag.next().coverLine());
 
         JPanel portsPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
 


### PR DESCRIPTION
Add ability to select program command, bootloader file/offset and partition table file/offset.

The ability to flash the bootloader and partition table binary files is required when working with the ESP-IDF framework.

Furthermore, openocd v0.11.0 (build 20220706) doesn't seem to support the command `program_esp32` that is used by this plugin, so I've added the ability to select whether `program` or `program_esp32` should be used.

Sorry for the messy code, this is my first time working with Java