### PR TITLE
The new simple logic to solve issue "Popup Stuck"

### DIFF
--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
@@ -45,7 +45,7 @@ public class OpenOcdComponent {
 
     private final static String[] FAIL_STRINGS = {
             "** Programming Failed **", "communication failure", "** OpenOCD init failed **"};
-    private static final String FLASH_SUCCESS_TEXT_REG = "(.*)Programming Finished(.*)";
+    private static final String FLASH_SUCCESS_TEXT = "Download program complete!";
     private static final Logger LOG = Logger.getInstance(OpenOcdComponent.class);
     private static final String ADAPTER_SPEED = "adapter speed";
 
@@ -116,6 +116,8 @@ public class OpenOcdComponent {
             commandLine.addParameters("-c", "init; reset");
         }
 
+        commandLine.addParameters("-c", "echo \"Download program complete!\" ");
+
         if (shutdown) {
             commandLine.addParameters("-c", "shutdown");
         }
@@ -185,32 +187,19 @@ public class OpenOcdComponent {
     public enum Flashed_STATUS {
         INITIALIZED {
             public Flashed_STATUS nextState() {
-                return BOOTLOADER_OK;
+                return APP_OK;
             }
         },
-        BOOTLOADER_OK {
+        APP_OK {
             public Flashed_STATUS nextState() {
-                return PARTITIONTABLE_OK;
-            }
-        },
-        PARTITIONTABLE_OK {
-            public Flashed_STATUS nextState() {
-                return APPIMAGE_OK;
-            }
-        },
-        APPIMAGE_OK {
-            public Flashed_STATUS nextState() {
-                return APPIMAGE_OK;
+                return APP_OK;
             }
         };
-
         public abstract Flashed_STATUS nextState();
     }
 
     private class ErrorFilter implements Filter {
         private final Project project;
-
-        private Flashed_STATUS FSTATUS_FILTER = Flashed_STATUS.INITIALIZED;
 
         ErrorFilter(Project project) {
             this.project = project;
@@ -236,10 +225,8 @@ public class OpenOcdComponent {
                         return HighlighterLayer.ERROR;
                     }
                 };
-            } else if (line.matches(FLASH_SUCCESS_TEXT_REG)) {
-                FSTATUS_FILTER = FSTATUS_FILTER.nextState();
-                if (FSTATUS_FILTER == Flashed_STATUS.APPIMAGE_OK)
-                    Informational.showSuccessfulDownloadNotification(project);
+            } else if (line.equals(FLASH_SUCCESS_TEXT)) {
+                Informational.showSuccessfulDownloadNotification(project);
             }
             return null;
         }
@@ -285,15 +272,15 @@ public class OpenOcdComponent {
             } else if (vRunFile == null && text.startsWith(ADAPTER_SPEED)) {
                 reset();
                 set(STATUS.FLASH_SUCCESS);
-            } else if (text.matches(FLASH_SUCCESS_TEXT_REG)) {
-                FSTATUS_LISTEN = FSTATUS_LISTEN.nextState();
-                if (FSTATUS_LISTEN == Flashed_STATUS.APPIMAGE_OK) {
+            } else if (text.contains(FLASH_SUCCESS_TEXT)) {
+                if (FSTATUS_LISTEN == Flashed_STATUS.APP_OK){
                     reset();
                     if (vRunFile != null) {
                         UPLOAD_LOAD_COUNT_KEY.set(vRunFile, vRunFile.getModificationCount());
                     }
                     set(STATUS.FLASH_SUCCESS);
                 }
+                FSTATUS_LISTEN = FSTATUS_LISTEN.nextState();
             } else if (text.startsWith(ERROR_PREFIX) && !containsOneOf(text, IGNORED_STRINGS)) {
                 reset();
                 set(STATUS.FLASH_WARNING);


### PR DESCRIPTION
Firstly, I am very sorry for the mistake made in the previous PR.
I tried to use the method of finding strings and enumerating state machines to determine whether the programming of openocd is complete, but the string detection in the `processlistener` process still didn't work, so the code after the first PR still caused a program deadlock.

I accidentally noticed that the JetBrains official OpenOCD plugin's command ended up using an `echo` command to output `(((ready)))`.Just as follow:
![Screenshot 2023-07-07 175511](https://github.com/ThexXTURBOXx/clion-embedded-esp32/assets/35221897/479381f0-dec6-4d68-a00e-af7f0213b3e8)
This is so clever that if OpenOCD quits unexpectedly, the program will not execute here, and naturally the `echo` command will not be executed.Just as follow:
```Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselecting 'jtag'
Info : esp_usb_jtag: VID set to 0x303a and PID to 0x1001
Info : esp_usb_jtag: capabilities descriptor set to[0m 0x2000
adapter speed: 40000 kHz
Warn : Interface already configured, ignoring
Info : esp_usb_jtag: VID set to 0x303a and PID to 0x1001
Info : esp_usb_jtag: capabilities descriptor set to 0x2000
Warn : Transport "jtag" was already selected
** program_esp input args <0x0 verify> **
Error: esp_usb_jtag: could not find or open device!
** OpenOCD init failed **
shutdown command invoked
D:\Espressif\tools\openocd-esp32\v0.12.0-esp32-20230419\openocd-esp32\share\open
ocd\scripts/target/esp_common.cfg:4: Error:
at file "D:\Espressif\tools\openocd-esp32\v0.12.0-esp32-20230419\openocd-esp32\s
hare\openocd\scripts/target/esp_common.cfg", line 4
```
So instead of caring about the number of intermediate downloads and bothering to count the programming finished strings, only just need to focus on the last echo. If the echo is successful, it means the burning is finished and the future task should return the downloadstatus.
Finally,I compiled the source code, generated the plugin zip, and put it into the **distribution's CLion** to run it (not IntelliJ's own) and it worked well (the perform parameter is always).
![Screenshot 2023-07-07 182649](https://github.com/ThexXTURBOXx/clion-embedded-esp32/assets/35221897/d5b2fc51-f32a-48f2-9960-dd196658dea5)

Fixes #4 
