### PR TITLE
Fix root path used by some functions

### DIFF
--- a/src/main/java/esp32/embedded/clion/openocd/FileChooseInput.java
+++ b/src/main/java/esp32/embedded/clion/openocd/FileChooseInput.java
@@ -22,7 +22,8 @@ public abstract class FileChooseInput extends TextFieldWithBrowseButton {
 
     public static final String BOARD_FOLDER = "board";
     public static final String INTERFACE_FOLDER = "interface";
-    public static final String BIN_FOLDER = "bin";
+    public static final String BOOT_BIN_FOLDER = "bootloader";
+    public static final String PART_BIN_FOLDER = "partition_table";
     protected final TextFieldValueEditor<VirtualFile> editor;
     private final FileChooserDescriptor fileDescriptor;
 
@@ -236,10 +237,12 @@ public abstract class FileChooseInput extends TextFieldWithBrowseButton {
     public static class BinFile extends FileChooseInput {
 
         private final VirtualFile projectHome;
+        private final String valueName;
 
         public BinFile(String valueName, VirtualFile defValue, VirtualFile projectHome) {
             super(valueName, defValue);
             this.projectHome = projectHome;
+            this.valueName = valueName;
         }
 
         public String getPath() {
@@ -257,9 +260,17 @@ public abstract class FileChooseInput extends TextFieldWithBrowseButton {
         @Override
         protected VirtualFile getDefaultLocation() {
             if (projectHome != null) {
-                VirtualFile bin = projectHome.findFileByRelativePath(BIN_FOLDER);
-                if (bin != null) {
-                    return bin;
+                if (valueName == "Bootloader file") {
+                    VirtualFile bin = projectHome.findFileByRelativePath(BOOT_BIN_FOLDER);
+                    if (bin != null) {
+                        return bin;
+                    }
+                }
+                if (valueName == "Partition Table file") {
+                    VirtualFile bin = projectHome.findFileByRelativePath(PART_BIN_FOLDER);
+                    if (bin != null) {
+                        return bin;
+                    }
                 }
             }
             return super.getDefaultLocation();

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfiguration.java
@@ -234,7 +234,7 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         element.setAttribute(ATTR_BOOT_OFFSET_CONFIG, Objects.requireNonNullElse(bootloaderOffset, DEF_BOOT_OFFSET));
 
         element.setAttribute(ATTR_PART_PATH_SET_CONFIG, String.valueOf(partitionBinPathSet));
-        element.setAttribute(ATTR_BOOT_PATH_CONFIG, partitionBinPath == null ? "" : partitionBinPath);
+        element.setAttribute(ATTR_PART_PATH_CONFIG, partitionBinPath == null ? "" : partitionBinPath);
         element.setAttribute(ATTR_PART_OFFSET_CONFIG, Objects.requireNonNullElse(partitionOffset, DEF_PART_OFFSET));
 
         element.setAttribute(ATTR_PROGRAM_TYPE_CONFIG, programType.name());

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
@@ -100,7 +100,7 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
         interfaceConfigFile.setText(ocd.getInterfaceConfigFile());
 
         String root = ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0])
-                .getExcludeRoots()[0].getPath();
+                .getExcludeRoots()[0].getParent().getPath();
 
         String bootBinPath = ocd.getBootBinPath();
         if (bootBinPath != null)
@@ -150,8 +150,8 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
                 this::getOpenocdHome);
         panel.add(interfaceConfigFile, gridBag.next().coverLine());
 
-        VirtualFile contentRoot =
-                ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0]).getExcludeRoots()[0];
+        VirtualFile contentRoot = ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0])
+                .getExcludeRoots()[0].getParent();
 
         JPanel bootloaderPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
         bootloaderPanel.add(new JLabel("Bootloader binary:"));

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdConfigurationEditor.java
@@ -100,7 +100,7 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
         interfaceConfigFile.setText(ocd.getInterfaceConfigFile());
 
         String root = ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0])
-                .getContentRoots()[0].getPath();
+                .getExcludeRoots()[0].getPath();
 
         String bootBinPath = ocd.getBootBinPath();
         if (bootBinPath != null)
@@ -151,7 +151,7 @@ public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettings
         panel.add(interfaceConfigFile, gridBag.next().coverLine());
 
         VirtualFile contentRoot =
-                ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0]).getContentRoots()[0];
+                ModuleRootManager.getInstance(ModuleManager.getInstance(myProject).getModules()[0]).getExcludeRoots()[0];
 
         JPanel bootloaderPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
         bootloaderPanel.add(new JLabel("Bootloader binary:"));


### PR DESCRIPTION
## Why PR?
I've found that the intent of these variables, whether `String root` or `VirtualFile contentRoot`, is to get the currently open project directory.
However, because of CMake, the current project directory is compiled into modules and merged into ESP-IDF.
So in fact, it points to the root directory of the entire ESP-IDF, not the project directory we opened.
## How?
CMake's build directory is globally unique, so I found the build directory first and then got the parrent directory to find the current working directory.
Also I added some code to make it faster to index relevant directories.
