### PR TITLE
Fix for Issue #21 -CLion 2024.2 does not work for OpenOCD Debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .qodana
 build
 release\.properties
+.DS_Store
+gradle/.DS_Store

--- a/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
+++ b/src/main/java/esp32/embedded/clion/openocd/OpenOcdComponent.java
@@ -10,6 +10,7 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.util.ExecutionErrorDialog;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
@@ -186,7 +187,7 @@ public final class OpenOcdComponent {
                     .withStop(process::destroyProcess,
                             () -> !process.isProcessTerminated() && !process.isProcessTerminating());
 
-            openOCDConsole.run();
+            ApplicationManager.getApplication().invokeLater(openOCDConsole::run);
             ret.obtrudeValue(null); // Unneeded. Complete anyway.
             return downloadFollower;
         } catch (ExecutionException e) {


### PR DESCRIPTION
The process crashes because it writes to objects that are only accessible by the EDT thread. This commit wraps those statements into .invokeLater and .invokeAndWait statements to resolve the issue.

Fixes #21 